### PR TITLE
View options consistency specs

### DIFF
--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -350,6 +350,14 @@ describe('collection view', function() {
     });
   });
 
+  describe('when instantiating a view with a different sort option than in the view\'s definition', function () {
+    it('should maintain the instantiated sort option', function () {
+      this.CollectionView = Marionette.CollectionView.extend({ sort: false }); 
+      this.newCollectionView = new this.CollectionView({ sort: true });
+      expect(this.newCollectionView.getOption('sort')).to.equal(true);
+    });
+  });
+
   describe('when a model is added to the collection', function() {
     beforeEach(function() {
       this.collection = new Backbone.Collection();

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -192,6 +192,29 @@ describe('base view', function() {
     });
   });
 
+  // http://backbonejs.org/#View-constructor
+  describe('when constructing a view with Backbone viewOptions', function () {
+    it('should attach the viewOptions to the view if options are on the view', function () {
+      this.MyView = Marionette.View.extend({
+        options: {
+          className: '.some-class'
+        } 
+      });
+      this.myView = new this.MyView();
+      expect(this.myView.className).to.equal('.some-class');
+    });
+
+    it('should attach the viewOptions to the view if options are passed as a function', function () {
+      var options = function(){
+        return {
+          className: '.some-class'
+        };
+      };  
+      this.myView = new Marionette.View(options);
+      expect(this.myView.className).to.equal('.some-class');
+    });
+  });
+
   describe('should expose its options in the constructor', function() {
     beforeEach(function() {
       this.options = {foo: 'bar'};


### PR DESCRIPTION
- Test for Backbone.View viewOptions when options passed as function
- Test for Backbone.View viewOptions when options is set on View definition
- Test for 'sort' when CollectionView instantiation overrides CollectionView definition sort
